### PR TITLE
SII-4119: Stop Kubernetes nodes from showing up as the address used to connect to Kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Array of the nodes from which the this plugin should collect metrics. This enabl
 
 ### kubelet_address (string) (optional)
 
-The address that Kubelet is on. This can be a hostname or an IP address. If this is not provided, node_name is used to fetch metrics from the Kubelet API.
+The hostname or IP address that kubelet will use to connect to. If not supplied, status.hostIP of the node is used to fetch metrics from the Kubelet API (via the $KUBERNETES_NODE_IP environment variable).
 
-Default value: `nil`.
+Default value: `"#{ENV['KUBERNETES_NODE_IP']}"`.
 
 ### kubelet_port (integer) (optional)
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ The name of the node from which the plugin should collect metrics. This enables 
 
 Array of the nodes from which the this plugin should collect metrics. This enables the plugin to fetch metrics from kubeapiserver. Used only when use_rest_client configuration parameter is not enabled. 
 
+### kubelet_address (string) (optional)
+
+The address that Kubelet is on. This can be a hostname or an IP address. If this is not provided, node_name is used to fetch metrics from the Kubelet API.
+
+Default value: `nil`.
+
 ### kubelet_port (integer) (optional)
 
-The port that kubelet is listening to.
+The port that kubelet is listening on.
 
 Default value: `10250`.
 

--- a/lib/fluent/plugin/in_kubernetes_metrics.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics.rb
@@ -61,8 +61,8 @@ module Fluent
       desc 'Name of the nodes that this plugin should collect metrics from.'
       config_param :node_names, :array, default: [], value_type: :string
 
-      desc 'The hostname or IP address that kubelet will use to connect to. If not supplied, node_name will be used instead.'
-      config_param :kubelet_address, :string, default: nil
+      desc 'The hostname or IP address that kubelet will use to connect to. If not supplied, status.hostIP of the node is used to fetch metrics from the Kubelet API (via the $KUBERNETES_NODE_IP environment variable)'
+      config_param :kubelet_address, :string, default: "#{ENV['KUBERNETES_NODE_IP']}"
 
       desc 'The port that kubelet is listening to.'
       config_param :kubelet_port, :integer, default: 10_250
@@ -196,11 +196,7 @@ module Fluent
       end
 
       def initialize_rest_client
-        if @kubelet_address.nil?
-          env_host = @node_name
-        else
-          env_host = @kubelet_address
-        end
+        env_host = @kubelet_address
         env_port = @kubelet_port
 
         if env_host && env_port

--- a/lib/fluent/plugin/in_kubernetes_metrics.rb
+++ b/lib/fluent/plugin/in_kubernetes_metrics.rb
@@ -61,6 +61,9 @@ module Fluent
       desc 'Name of the nodes that this plugin should collect metrics from.'
       config_param :node_names, :array, default: [], value_type: :string
 
+      desc 'The hostname or IP address that kubelet will use to connect to. If not supplied, node_name will be used instead.'
+      config_param :kubelet_address, :string, default: nil
+
       desc 'The port that kubelet is listening to.'
       config_param :kubelet_port, :integer, default: 10_250
 
@@ -193,7 +196,11 @@ module Fluent
       end
 
       def initialize_rest_client
-        env_host = @node_name
+        if @kubelet_address.nil?
+          env_host = @node_name
+        else
+          env_host = @kubelet_address
+        end
         env_port = @kubelet_port
 
         if env_host && env_port


### PR DESCRIPTION
* Add kubelet_address as an alternative address to use to connect to Kubelet in place of node_name.
  - This relates to ADDON-21681

This enables the following PR in splunk-connect-for-kubernetes: [1]

[1] https://github.com/splunk/splunk-connect-for-kubernetes/pull/137